### PR TITLE
Bump build-tools to 33.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ android {
     namespace "at.bitfire.cert4android"
 
     compileSdkVersion 33
-    buildToolsVersion '33.0.0'
+    buildToolsVersion '33.0.2'
 
     defaultConfig {
         minSdkVersion 21            // Android 5


### PR DESCRIPTION
Fixes AIDL build failure on Windows

See
https://issuetracker.google.com/issues/236167971
https://developer.android.com/studio/releases/build-tools