### PR TITLE
Upgraded SDK to 34

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "at.bitfire.cert4android"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 21            // Android 5

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 
     defaultConfig {
         minSdk = 21            // Android 5
-        targetSdk = 33         // Android 13
 
         aarMetadata {
             minCompileSdk = 29

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'at.bitfire.cert4android.demo'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "at.bitfire.cert4android.demo"
@@ -13,7 +13,7 @@ android {
         versionName "1.0.0"
 
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Note that `targetSdk` has been deprecated, and it's no longer necessary, at least in Gradle KTS.