### PR TITLE
Increase compile SDK

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 android {
     namespace = "at.bitfire.cert4android"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21            // Android 5

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         minSdk = 21            // Android 5
-        targetSdk = 34
 
         aarMetadata {
             minCompileSdk = 29


### PR DESCRIPTION
- Increased `compileSdk` to `35`
- Removed `targetSdk` (it's no longer required and will be removed in a future update of AGP)