### PR TITLE
Upgrade AGP to 8.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.2"
+agp = "8.9.0"
 androidx-activityCompose = "1.10.1"
 androidx-appcompat = "1.7.0"
 androidx-core = "1.15.0"


### PR DESCRIPTION
According to [Versioning changes](https://developer.android.com/build/releases/gradle-plugin#versioning-update), there shouldn't be any breaking changes.

Android Studio Meerkat 2024.3.1 is required though