### PR TITLE
Remove last continuation in list when cancelled

### DIFF
--- a/lib/src/main/java/at/bitfire/cert4android/UserDecisionRegistry.kt
+++ b/lib/src/main/java/at/bitfire/cert4android/UserDecisionRegistry.kt
@@ -53,16 +53,16 @@ class UserDecisionRegistry private constructor(
             // User decision possible → remember request in pendingDecisions so that a later decision will be applied to this request
 
             cont.invokeOnCancellation {
-                val decisionsList = pendingDecisions[cert]
-
-                // remove from pending decisions on cancellation
                 synchronized(pendingDecisions) {
-                    decisionsList?.remove(cont)
-                }
+                    val decisionsList = pendingDecisions[cert]
 
-                // Remove decisions list if empty
-                if (decisionsList?.isEmpty() == true)
-                    pendingDecisions.remove(cert)
+                    // remove from pending decisions on cancellation
+                    decisionsList?.remove(cont)
+
+                    // Remove decisions list if empty
+                    if (decisionsList?.isEmpty() == true)
+                        pendingDecisions -= cert
+                }
 
                 val nm = NotificationUtils.createChannels(context)
                 nm.cancel(CertUtils.getTag(cert), NotificationUtils.ID_CERT_DECISION)

--- a/lib/src/main/java/at/bitfire/cert4android/UserDecisionRegistry.kt
+++ b/lib/src/main/java/at/bitfire/cert4android/UserDecisionRegistry.kt
@@ -53,10 +53,16 @@ class UserDecisionRegistry private constructor(
             // User decision possible → remember request in pendingDecisions so that a later decision will be applied to this request
 
             cont.invokeOnCancellation {
+                val decisionsList = pendingDecisions[cert]
+
                 // remove from pending decisions on cancellation
                 synchronized(pendingDecisions) {
-                    pendingDecisions[cert]?.remove(cont)
+                    decisionsList?.remove(cont)
                 }
+
+                // Remove decisions list if empty
+                if (decisionsList?.isEmpty() == true)
+                    pendingDecisions.remove(cert)
 
                 val nm = NotificationUtils.createChannels(context)
                 nm.cancel(CertUtils.getTag(cert), NotificationUtils.ID_CERT_DECISION)


### PR DESCRIPTION
The UI (`requestDecision()`) will not be called again if `pendindDecision[cert]` still contains an empty list (the map entry not removed or set to null).

This would become a problem when the user leaves the app while the dialog is open, such that the request gets canceled and then a new request is made (maybe because the user retries the sync). The certificate dialog would then probably not be shown again, which is bad.

I have added a test and the conditional removal.